### PR TITLE
Fixing raising an argument error when there's no callback

### DIFF
--- a/app/controllers/refinery/authentication/devise/sessions_controller.rb
+++ b/app/controllers/refinery/authentication/devise/sessions_controller.rb
@@ -7,7 +7,7 @@ module Refinery
 
         before_action :clear_unauthenticated_flash, :only => [:new]
         before_action :force_signup_when_no_users!
-        skip_before_action :detect_authentication_devise_user!, only: [:create]
+        skip_before_action :detect_authentication_devise_user!, only: [:create], raise: false
         after_action :detect_authentication_devise_user!, only: [:create]
 
         def create


### PR DESCRIPTION
We should not raise a ArgumentError if `detect_authentication_devise_user!` doesn't exist. I've tested this on our production app and this will fix raising the error.

I've based this fix on: https://github.com/nsarno/knock/issues/138#issue-203899018